### PR TITLE
Update the import paths for Caddyserver

### DIFF
--- a/setup_caddyserver.go
+++ b/setup_caddyserver.go
@@ -13,8 +13,8 @@ import (
 	"unicode"
 
 	"blitznote.com/src/http.upload/signature.auth"
-	"github.com/mholt/caddy"
-	"github.com/mholt/caddy/caddyhttp/httpserver"
+	"github.com/caddyserver/caddy"
+	"github.com/caddyserver/caddy/caddyhttp/httpserver"
 	"golang.org/x/text/unicode/norm"
 )
 

--- a/setup_test.go
+++ b/setup_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"unicode"
 
-	"github.com/mholt/caddy"
-	"github.com/mholt/caddy/caddyhttp/httpserver"
+	"github.com/caddyserver/caddy"
+	"github.com/caddyserver/caddy/caddyhttp/httpserver"
 	. "github.com/smartystreets/goconvey/convey"
 	"golang.org/x/text/unicode/norm"
 )

--- a/upload_test.go
+++ b/upload_test.go
@@ -16,8 +16,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mholt/caddy"
-	"github.com/mholt/caddy/caddyhttp/httpserver"
+	"github.com/caddyserver/caddy"
+	"github.com/caddyserver/caddy/caddyhttp/httpserver"
 
 	. "github.com/smartystreets/goconvey/convey"
 )


### PR DESCRIPTION
This pull request makes http.upload compatible with Caddyserver v1.0.1+ (see epicagency/caddy-expires#6 for reference) by updating the import paths for Caddyserver.